### PR TITLE
チャプター管理横のボタンが表示されない不具合を修正

### DIFF
--- a/src/components/Modules/ProjectTreeMenu.vue
+++ b/src/components/Modules/ProjectTreeMenu.vue
@@ -115,7 +115,6 @@ export default Vue.extend({
 }
 
 .ProjectMenu__Item svg {
-  display: none;
   fill: #fff;
 }
 


### PR DESCRIPTION
# これは

<img width="226" alt="flight_books" src="https://user-images.githubusercontent.com/10248/47604716-7160e780-da38-11e8-88bc-181145b0bd66.png">

なぜかボタンがdisplay:noneされていたので表示させる