### PR TITLE
チャプター横のボタンが表示されない不具合を修正

### DIFF
--- a/src/components/Modules/ChapterMenu.vue
+++ b/src/components/Modules/ChapterMenu.vue
@@ -141,7 +141,6 @@ export default Vue.extend({
 }
 
 .ChapterMenu__Item svg {
-  display: none;
   fill: #fff;
 }
 


### PR DESCRIPTION
<img width="427" alt="flight_books" src="https://user-images.githubusercontent.com/10248/47721444-753c7600-dc93-11e8-8d64-87177280d15b.png">
