### PR TITLE
左メニューが狭すぎて見づらくなるのでmin-widthを設定

### DIFF
--- a/src/containers/Book/Detail/index.vue
+++ b/src/containers/Book/Detail/index.vue
@@ -113,6 +113,7 @@ export default Vue.extend({
 
 .BookDetail__Left {
   flex: 2;
+  min-width: 200px;
   height: 100vh;
   background-color: #2e3235;
 }


### PR DESCRIPTION
# 修正前
<img width="396" alt="flight_books" src="https://user-images.githubusercontent.com/10248/47948860-36047280-df7c-11e8-9fb1-709cfb9443cb.png">

# 修正後
<img width="425" alt="flight_books" src="https://user-images.githubusercontent.com/10248/47948866-461c5200-df7c-11e8-89eb-7e3d19a9f267.png">

# コメント

スマホで見ると左メニューが幅を取りすぎて有害な修正になりそうですが、どっちにしても今のレイアウトでスマホから執筆するのは無理だと思うので

- スマホ対応が必要なら別に考えることにして、とりあえず今はPCで見やすいことを優先してmin-widthをつけたい

という提案です。

もしなんか方針が違うようだったらrejectでもぜんぜん構わないです。
